### PR TITLE
Split Actions in PyTest and flake8 with badges

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-complexity = 10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ name: flake8
 
 on:
   push:
-    branches: [ main, tests_actions ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: flake8
+
+on:
+  push:
+    branches: [ main, tests_actions ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 requests
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        flake8 . --count --show-source --statistics

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,11 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, tests_actions ]
   pull_request:
     branches: [ main ]
 
@@ -31,9 +31,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ name: Pytest
 
 on:
   push:
-    branches: [ main, tests_actions ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Tests
+name: Pytest
 
 on:
   push:
@@ -27,12 +27,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest mock requests
+        python -m pip install pytest mock requests
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         python -m pytest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![Tests Python 3.7](https://github.com/Liscare/markdownToWiki/actions/workflows/main.yml/badge.svg)
+![Lint with flake8](https://github.com/Liscare/markdownToWiki/actions/workflows/lint.yml/badge.svg)
+![Tests Python 3.7 | 3.8 | 3.9](https://github.com/Liscare/markdownToWiki/actions/workflows/tests.yml/badge.svg)
+![Last commit](https://github.com/Liscare/markdownToWiki/commit/master)
 
 # Introduction
 Simple script inserting Wikipedia links in your markdown document

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![flake8](https://github.com/Liscare/markdownToWiki/actions/workflows/lint.yml/badge.svg)](https://github.com/Liscare/markdownToWiki/actions/workflows/lint.yml)
 [![Pytest](https://github.com/Liscare/markdownToWiki/actions/workflows/tests.yml/badge.svg)](https://github.com/Liscare/markdownToWiki/actions/workflows/tests.yml)
-![Last commit](https://github.com/Liscare/markdownToWiki/commit/master)
 
 # Introduction
 Simple script inserting Wikipedia links in your markdown document

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Tests Python 3.7](https://github.com/Liscare/markdownToWiki/actions/workflows/main.yml/badge.svg)
+
 # Introduction
 Simple script inserting Wikipedia links in your markdown document
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Lint with flake8](https://github.com/Liscare/markdownToWiki/actions/workflows/lint.yml/badge.svg)
-![Tests Python 3.7 | 3.8 | 3.9](https://github.com/Liscare/markdownToWiki/actions/workflows/tests.yml/badge.svg)
+[![flake8](https://github.com/Liscare/markdownToWiki/actions/workflows/lint.yml/badge.svg)](https://github.com/Liscare/markdownToWiki/actions/workflows/lint.yml)
+[![Pytest](https://github.com/Liscare/markdownToWiki/actions/workflows/tests.yml/badge.svg)](https://github.com/Liscare/markdownToWiki/actions/workflows/tests.yml)
 ![Last commit](https://github.com/Liscare/markdownToWiki/commit/master)
 
 # Introduction


### PR DESCRIPTION
- Add Github actions for test (Pytest) and lint (flake8).
- Add badges for test and lint in README
